### PR TITLE
pipeline-from-config

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 * Added `raise_errors` argument to `find_pipelines`. If `True`, the first pipeline for which autodiscovery fails will cause an error to be raised. The default behaviour is still to raise a warning for each failing pipeline.
 * It is now possible to use Kedro without having `rich` installed.
 * Updated custom logging behavior: `conf/logging.yml` will be used if it exists and `KEDRO_LOGGING_CONFIG` is not set; otherwise, `default_logging.yml` will be used.
+* Can now define modular pipeline in `conf/pipelines.yml`
 
 ## Bug fixes and other changes
 * User defined catch-all dataset factory patterns now override the default pattern provided by the runner.

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -114,6 +114,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
             "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
             "credentials": ["credentials*", "credentials*/**", "**/credentials*"],
             "globals": ["globals.yml"],
+            "pipelines": ["pipelines.yml"],
         }
         self.config_patterns.update(config_patterns or {})
 

--- a/tests/framework/project/test_pipeline_discovery.py
+++ b/tests/framework/project/test_pipeline_discovery.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from kedro.framework.project import configure_project, find_pipelines
+from kedro.framework.project import configure_project, find_pipelines, from_config
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ def test_find_pipelines(mock_package_name_with_pipelines, pipeline_names):
     indirect=True,
 )
 def test_find_pipelines_skips_modules_without_create_pipelines_function(
-    mock_package_name_with_pipelines, pipeline_names
+        mock_package_name_with_pipelines, pipeline_names
 ):
     # Create a module without `create_pipelines` in the `pipelines` dir.
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
@@ -76,7 +76,7 @@ def test_find_pipelines_skips_modules_without_create_pipelines_function(
 
     configure_project(mock_package_name_with_pipelines)
     with pytest.warns(
-        UserWarning, match="module does not expose a 'create_pipeline' function"
+            UserWarning, match="module does not expose a 'create_pipeline' function"
     ):
         pipelines = find_pipelines()
     assert set(pipelines) == pipeline_names | {"__default__"}
@@ -89,7 +89,7 @@ def test_find_pipelines_skips_modules_without_create_pipelines_function(
     indirect=True,
 )
 def test_find_pipelines_skips_hidden_modules(
-    mock_package_name_with_pipelines, pipeline_names
+        mock_package_name_with_pipelines, pipeline_names
 ):
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
     pipeline_dir = pipelines_dir / ".ipynb_checkpoints"
@@ -120,7 +120,7 @@ def test_find_pipelines_skips_hidden_modules(
     indirect=True,
 )
 def test_find_pipelines_skips_modules_with_unexpected_return_value_type(
-    mock_package_name_with_pipelines, pipeline_names
+        mock_package_name_with_pipelines, pipeline_names
 ):
     # Define `create_pipelines` so that it does not return a `Pipeline`.
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
@@ -145,11 +145,11 @@ def test_find_pipelines_skips_modules_with_unexpected_return_value_type(
 
     configure_project(mock_package_name_with_pipelines)
     with pytest.warns(
-        UserWarning,
-        match=(
-            r"Expected the 'create_pipeline' function in the '\S+' "
-            r"module to return a 'Pipeline' object, got 'dict' instead."
-        ),
+            UserWarning,
+            match=(
+                    r"Expected the 'create_pipeline' function in the '\S+' "
+                    r"module to return a 'Pipeline' object, got 'dict' instead."
+            ),
     ):
         pipelines = find_pipelines()
     assert set(pipelines) == pipeline_names | {"__default__"}
@@ -162,7 +162,7 @@ def test_find_pipelines_skips_modules_with_unexpected_return_value_type(
     indirect=True,
 )
 def test_find_pipelines_skips_regular_files_within_the_pipelines_folder(
-    mock_package_name_with_pipelines, pipeline_names
+        mock_package_name_with_pipelines, pipeline_names
 ):
     # Create a regular file (not a subdirectory) in the `pipelines` dir.
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
@@ -186,7 +186,7 @@ def test_find_pipelines_skips_regular_files_within_the_pipelines_folder(
     indirect=["mock_package_name_with_pipelines", "pipeline_names"],
 )
 def test_find_pipelines_skips_modules_that_cause_exceptions_upon_import(
-    mock_package_name_with_pipelines, pipeline_names, raise_errors
+        mock_package_name_with_pipelines, pipeline_names, raise_errors
 ):
     # Create a module that will result in errors when we try to load it.
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
@@ -196,8 +196,8 @@ def test_find_pipelines_skips_modules_that_cause_exceptions_upon_import(
 
     configure_project(mock_package_name_with_pipelines)
     with getattr(pytest, "raises" if raise_errors else "warns")(
-        ImportError if raise_errors else UserWarning,
-        match=r"An error occurred while importing the '\S+' module.",
+            ImportError if raise_errors else UserWarning,
+            match=r"An error occurred while importing the '\S+' module.",
     ):
         pipelines = find_pipelines(raise_errors=raise_errors)
     if not raise_errors:
@@ -211,7 +211,7 @@ def test_find_pipelines_skips_modules_that_cause_exceptions_upon_import(
     indirect=True,
 )
 def test_find_pipelines_handles_simplified_project_structure(
-    mock_package_name_with_pipelines, pipeline_names
+        mock_package_name_with_pipelines, pipeline_names
 ):
     (Path(sys.path[0]) / mock_package_name_with_pipelines / "pipeline.py").write_text(
         textwrap.dedent(
@@ -241,7 +241,7 @@ def test_find_pipelines_handles_simplified_project_structure(
     indirect=["mock_package_name_with_pipelines", "pipeline_names"],
 )
 def test_find_pipelines_skips_unimportable_pipeline_module(
-    mock_package_name_with_pipelines, pipeline_names, raise_errors
+        mock_package_name_with_pipelines, pipeline_names, raise_errors
 ):
     (Path(sys.path[0]) / mock_package_name_with_pipelines / "pipeline.py").write_text(
         textwrap.dedent(
@@ -259,8 +259,8 @@ def test_find_pipelines_skips_unimportable_pipeline_module(
 
     configure_project(mock_package_name_with_pipelines)
     with getattr(pytest, "raises" if raise_errors else "warns")(
-        ImportError if raise_errors else UserWarning,
-        match=r"An error occurred while importing the '\S+' module.",
+            ImportError if raise_errors else UserWarning,
+            match=r"An error occurred while importing the '\S+' module.",
     ):
         pipelines = find_pipelines(raise_errors=raise_errors)
     if not raise_errors:
@@ -274,7 +274,7 @@ def test_find_pipelines_skips_unimportable_pipeline_module(
     indirect=["mock_package_name_with_pipelines"],
 )
 def test_find_pipelines_handles_project_structure_without_pipelines_dir(
-    mock_package_name_with_pipelines, simplified
+        mock_package_name_with_pipelines, simplified
 ):
     # Delete the `pipelines` directory to simulate a project without it.
     pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
@@ -282,7 +282,7 @@ def test_find_pipelines_handles_project_structure_without_pipelines_dir(
 
     if simplified:
         (
-            Path(sys.path[0]) / mock_package_name_with_pipelines / "pipeline.py"
+                Path(sys.path[0]) / mock_package_name_with_pipelines / "pipeline.py"
         ).write_text(
             textwrap.dedent(
                 """
@@ -301,3 +301,19 @@ def test_find_pipelines_handles_project_structure_without_pipelines_dir(
     assert sum(pipelines.values()).outputs() == (
         {"simple_pipeline"} if simplified else set()
     )
+
+
+@pytest.fixture
+def mock_config(pipeline_names):
+    return dict(pipe=pipeline_names)
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines,pipeline_names",
+    [(x, x) for x in [set(), {"my_pipeline"}]],
+    indirect=True,
+)
+def test_from_config(mock_package_name_with_pipelines, mock_config, pipeline_names):
+    configure_project(mock_package_name_with_pipelines)
+    pipeline_from_config = from_config(mock_config)
+    assert pipeline_from_config.outputs() == pipeline_names


### PR DESCRIPTION
## Description
As a Kedro user I have always wanted to be able to define modular pipelines in a config file. I believe that doing so will reduce the likelihood of a user inadvertently impacting a pipeline other than the one intended.

## Development notes
I have adjusted two files:
`comegaconf_config.py` now has `"pipelines": ["pipelines.yml"],` added to its `config_patterns`
`kedro/framework/project/__init__.py` has an additional function `from_config` that can read a config entry and build the entry into a modular pipeline which is then returned.
A portion of `find_pipelines` was abstracted into a helper function `_get_pipeline_obj` for use in both functions.
This was tested using `make test` and manually tested with the default example_pipeline created when creating a new Kedro project.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [X] Added tests to cover my changes
- [X] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team